### PR TITLE
feat: Implement event management UI and add PgAdmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ docker-compose up -d
 - Backend API: http://localhost:8000
 - Documentación API: http://localhost:8000/docs
 
+### PostgreSQL Admin (PgAdmin)
+
+This project includes PgAdmin, a web-based administration tool for PostgreSQL. You can use it to view and manage the `banquet_db` database.
+
+**Accessing PgAdmin:**
+
+*   URL: [http://localhost:5050](http://localhost:5050)
+*   Default Email: `admin@banquet.pro`
+*   Default Password: `adminpassword`
+
+Upon logging into PgAdmin, you should find the "BanquetPro DB" server pre-configured under "Servers". This connection uses the `banquet_user` and its associated password (as defined in the `docker-compose.yml` environment for the PostgreSQL service and utilized via a pgpass file for seamless authentication within PgAdmin). You can directly browse the database schema, tables, and execute SQL queries.
+
 ## 📁 Estructura del Proyecto
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,9 +78,32 @@ services:
       retries: 5
       start_period: 10s
 
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: banquet-pgadmin
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@banquet.pro
+      - PGADMIN_DEFAULT_PASSWORD=adminpassword
+      # PGADMIN_SERVER_JSON_FILE: "/pgadmin4/servers.json" # This is how we tell pgAdmin to load the server config
+      # PGADMIN_DISABLE_POSTFIX: "true" # Optional: if you want to disable the email postfix warning
+      # SCRIPT_NAME: "/pgadmin4" # If running pgadmin behind a reverse proxy with a subpath
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+      - ./pgadmin-servers.json:/pgadmin4/servers.json:ro
+      - ./pgpass:/pgadmin4/pgpass:ro # Mount the password file
+    ports:
+      - "5050:80" # Expose PgAdmin on host port 5050, listening on container port 80
+    networks:
+      - banquet-network
+    depends_on:
+      postgres:
+        condition: service_healthy # Wait for postgres to be healthy
+    restart: unless-stopped
+
 volumes:
   postgres_data:
   redis_data:
+  pgadmin_data: # Add this line
 
 networks:
   banquet-network:

--- a/pgadmin-servers.json
+++ b/pgadmin-servers.json
@@ -1,0 +1,14 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "BanquetPro DB",
+      "Group": "Servers",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "banquet_db",
+      "Username": "banquet_user",
+      "SSLMode": "prefer",
+      "PassFile": "/pgadmin4/pgpass"
+    }
+  }
+}

--- a/pgpass
+++ b/pgpass
@@ -1,0 +1,1 @@
+postgres:5432:banquet_db:banquet_user:banquet_password


### PR DESCRIPTION
This commit introduces several enhancements:

Frontend (EventPlanningPage):
- Enables "View Details" button: Fetches and displays event details in a modal.
- Enables "Edit" button: Allows editing event details in a pre-filled form within a modal; updates backend.
- Enables "Delete" button: Implements event deletion with a confirmation modal; updates backend.
- All actions include toast notifications for success/failure.

DevOps & Database:
- Adds PgAdmin service to docker-compose.yml for PostgreSQL database administration.
- Configures PgAdmin with default credentials (admin@banquet.pro / adminpassword) and exposes it on port 5050.
- Includes pgadmin-servers.json and pgpass files to auto-configure and authenticate PgAdmin to the 'banquet_db' (host 'postgres', user 'banquet_user').
- Updates README.md with instructions on accessing and using PgAdmin.

These changes provide full CRUD functionality for events in the UI and add a database administration tool to the development environment.